### PR TITLE
Added support for emptying containers

### DIFF
--- a/module.txt
+++ b/module.txt
@@ -3,6 +3,11 @@
     "version" : "1.0.0-SNAPSHOT",
     "author" : "UltimateBudgie, Marcin Sciesinski <marcins78@gmail.com>, Mandar Juvekar",
     "displayName" : "Thirst and Drink",
-    "dependencies" : [],
+    "dependencies" : [
+         {
+             "id" : "Fluid",
+             "minVersion" : "1.0.0"
+         }
+     ],
     "description" : "This module introduces Thirst and various related effects."
 }

--- a/src/main/java/org/terasology/thirst/event/DrinkConsumedEvent.java
+++ b/src/main/java/org/terasology/thirst/event/DrinkConsumedEvent.java
@@ -15,8 +15,25 @@
  */
 package org.terasology.thirst.event;
 
+import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.entitySystem.event.Event;
+import org.terasology.logic.common.ActivateEvent;
 
 /** This event is sent to an entity to indicate that it has drunk a drink. */
 public class DrinkConsumedEvent implements Event {
+    private EntityRef instigator;
+    private EntityRef target;
+
+    public DrinkConsumedEvent(ActivateEvent event) {
+        this.instigator = event.getInstigator();
+        this.target = event.getTarget();
+    }
+
+    public EntityRef getInstigator() {
+        return instigator;
+    }
+
+    public EntityRef getTarget() {
+        return target;
+    }
 }


### PR DESCRIPTION
Ref- https://github.com/Terasology/Fluid/issues/10
and https://github.com/Terasology/Hunger/issues/4

To test:
- Enable Thirst, ManualLabor, Fluid
- console `give woodenCup`
- go near a water body, with the cup in hand and right click to fetch water. (This should fill the cup blue)
- go away and right click to drink. (This should now empty the cup)

To do this I have made the emptying code function when the DrinkConsumedEvent is triggered. This code relies on the Fluid module and therefore that is added as a dependency. In any case, I feel Thirst is pointless without the Fluid module. (You would need to fill a cup with water and drink it- all that is written in the FluidAuthoritySystem).