### PR TITLE
Fix JS WoodenCup

### DIFF
--- a/src/main/java/org/terasology/thirst/ThirstAuthoritySystem.java
+++ b/src/main/java/org/terasology/thirst/ThirstAuthoritySystem.java
@@ -172,7 +172,7 @@ public class ThirstAuthoritySystem extends BaseComponentSystem {
             thirst.lastCalculationTime = time.getGameTimeInMs();
             instigator.saveComponent(thirst);
             item.send(new DrinkConsumedEvent(event));
-
+            item.removeComponent(DrinkComponent.class);
             if (destroyDrink) {
                 event.consume();
                 destroyDrink = false;


### PR DESCRIPTION
Remove drink component from item after drink is consumed. 
This has been done to support the pr: https://github.com/Terasology/EdibleSubstance/pull/1