### PR TITLE
fix: Send AffectThirstEvent more often

### DIFF
--- a/src/main/java/org/terasology/thirst/ThirstAuthoritySystem.java
+++ b/src/main/java/org/terasology/thirst/ThirstAuthoritySystem.java
@@ -71,7 +71,6 @@ public class ThirstAuthoritySystem extends BaseComponentSystem {
     private DelayManager delayManager;
 
     private boolean destroyDrink;
-    private float expectedDecay;
 
     /**
      * The interval (in milliseconds) at which healthDecreaseAmount (thirstComponent) is applied to the component.
@@ -224,7 +223,7 @@ public class ThirstAuthoritySystem extends BaseComponentSystem {
      */
     @ReceiveEvent(components = {ThirstComponent.class})
     public void characterMoved(CharacterMoveInputEvent event, EntityRef character, ThirstComponent thirst) {
-        expectedDecay = event.isRunning() ? thirst.sprintDecayPerSecond : thirst.normalDecayPerSecond;
+        float expectedDecay = event.isRunning() ? thirst.sprintDecayPerSecond : thirst.normalDecayPerSecond;
         // Send event to allow for other systems to modify thirst decay.
         AffectThirstEvent affectThirstEvent = new AffectThirstEvent(expectedDecay);
         character.send(affectThirstEvent);

--- a/src/main/java/org/terasology/thirst/ThirstAuthoritySystem.java
+++ b/src/main/java/org/terasology/thirst/ThirstAuthoritySystem.java
@@ -44,6 +44,7 @@ import org.terasology.logic.players.event.OnPlayerSpawnedEvent;
 import org.terasology.registry.In;
 import org.terasology.thirst.component.DrinkComponent;
 import org.terasology.thirst.component.ThirstComponent;
+import org.terasology.thirst.event.AffectThirstEvent;
 import org.terasology.thirst.event.DrinkConsumedEvent;
 import org.terasology.world.WorldComponent;
 
@@ -227,7 +228,10 @@ public class ThirstAuthoritySystem extends BaseComponentSystem {
             // Recalculate current thirst and apply new decay
             thirst.lastCalculatedWater = ThirstUtils.getThirstForEntity(character);
             thirst.lastCalculationTime = time.getGameTimeInMs();
-            thirst.waterDecayPerSecond = expectedDecay;
+            // Send event to allow for other systems to modify thirst decay.
+            AffectThirstEvent affectThirstEvent = new AffectThirstEvent(expectedDecay);
+            character.send(affectThirstEvent);
+            thirst.waterDecayPerSecond = affectThirstEvent.getResultValue();
             character.saveComponent(thirst);
         }
     }

--- a/src/main/java/org/terasology/thirst/ThirstAuthoritySystem.java
+++ b/src/main/java/org/terasology/thirst/ThirstAuthoritySystem.java
@@ -225,6 +225,7 @@ public class ThirstAuthoritySystem extends BaseComponentSystem {
     @ReceiveEvent(components = {ThirstComponent.class})
     public void characterMoved(CharacterMoveInputEvent event, EntityRef character, ThirstComponent thirst) {
         expectedDecay = event.isRunning() ? thirst.sprintDecayPerSecond : thirst.normalDecayPerSecond;
+        // Send event to allow for other systems to modify thirst decay.
         AffectThirstEvent affectThirstEvent = new AffectThirstEvent(expectedDecay);
         character.send(affectThirstEvent);
         expectedDecay = affectThirstEvent.getResultValue();
@@ -232,7 +233,6 @@ public class ThirstAuthoritySystem extends BaseComponentSystem {
             // Recalculate current thirst and apply new decay
             thirst.lastCalculatedWater = ThirstUtils.getThirstForEntity(character);
             thirst.lastCalculationTime = time.getGameTimeInMs();
-            // Send event to allow for other systems to modify thirst decay.
             thirst.waterDecayPerSecond = expectedDecay;
             character.saveComponent(thirst);
         }

--- a/src/main/java/org/terasology/thirst/event/AffectThirstEvent.java
+++ b/src/main/java/org/terasology/thirst/event/AffectThirstEvent.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2020 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.thirst.event;
+
+import org.terasology.entitySystem.event.AbstractValueModifiableEvent;
+
+/**
+ * This event is sent out byt the {@link org.terasology.thirst.ThirstAuthoritySystem} to allow for other systems to
+ * modify thirst decay.
+ */
+public class AffectThirstEvent extends AbstractValueModifiableEvent {
+    public AffectThirstEvent(float baseValue) {
+        super(baseValue);
+    }
+}

--- a/src/main/java/org/terasology/thirst/event/AffectThirstEvent.java
+++ b/src/main/java/org/terasology/thirst/event/AffectThirstEvent.java
@@ -18,7 +18,7 @@ package org.terasology.thirst.event;
 import org.terasology.entitySystem.event.AbstractValueModifiableEvent;
 
 /**
- * This event is sent out byt the {@link org.terasology.thirst.ThirstAuthoritySystem} to allow for other systems to
+ * This event is sent out by the {@link org.terasology.thirst.ThirstAuthoritySystem} to allow for other systems to
  * modify thirst decay.
  */
 public class AffectThirstEvent extends AbstractValueModifiableEvent {


### PR DESCRIPTION
There was a slight error in AffectThirst which I just noticed. 
In the current condition affect thirst is sent out only when the player changes mode of movement (walking / running) which means thirst won't be modified if the player does not change the movement mode. This fixes the same.